### PR TITLE
Caching and improve for trading limits

### DIFF
--- a/base_strategy.py
+++ b/base_strategy.py
@@ -15,6 +15,7 @@ from freqtrade.strategy import (BooleanParameter, CategoricalParameter, DecimalP
 # Add your lib to import here
 import logging
 from freqtrade.constants import Config
+from freqtrade.exchange import timeframe_to_minutes
 from freqtrade.persistence import Order, PairLocks, Trade
 
 class BaseStrategy(IStrategy):
@@ -42,7 +43,7 @@ class BaseStrategy(IStrategy):
     # Check the documentation or the Sample strategy to get the latest version.
     INTERFACE_VERSION = 3
 
-    STRATEGY_VERSION_BASE = "1.6.0"
+    STRATEGY_VERSION_BASE = "1.7.0"
 
     # Optimal timeframe for the strategy.
     timeframe = '1h'
@@ -134,7 +135,10 @@ class BaseStrategy(IStrategy):
         :param **kwargs: Ensure to keep this here so updates to this won't break your strategy.
         """
     
-        # Setup removal of autolocaks
+        # Setup cache for dataframes
+        self.custom_info['cache'] = {}
+
+        # Setup removal of autolocks
         self.custom_info['remove-autolock'] = []
 
         # Call to super first
@@ -153,6 +157,10 @@ class BaseStrategy(IStrategy):
         :param current_time: datetime object, containing the current datetime
         :param **kwargs: Ensure to keep this here so updates to this won't break your strategy.
         """
+
+        # Run the cleanup of cache once every five minutes
+        if current_time.minute % 5 == 0 and current_time.second <= 10:
+            self.cleanup_cache()
 
         # Check if there are pairs set for which the Auto lock should be reoved
         if len(self.custom_info['remove-autolock']) > 0:
@@ -481,3 +489,85 @@ class BaseStrategy(IStrategy):
             until = pl.lock_end_time.strftime("%Y-%m-%d %H:%M:%S")
 
         return until
+
+
+    def cache_dataframe(self, df: DataFrame, pair: str, tf: str):
+        """
+        Store (or update) a dataframe for a certain pair and timeframe in the cache.
+        The dataframe is copied to make sure no alternations are made, and the 
+        current time will be stored in order to clean-up things later.
+
+        :param df: Dataframe to store
+        :param pair: Pair the Dataframe belongs to
+        :param tf: Timeframe the Dataframe belongs to
+        """
+
+        key = f"{pair}_{tf}"
+        if not key in self.custom_info['cache']:
+            # Create empty entry for this trade
+            self.custom_info['cache'][key] = {}
+            self.custom_info['cache'][key]['tf'] = tf
+
+            self.log(f"Created custom cache storage for {key}.")
+
+        self.custom_info['cache'][key]['df'] = df.copy()
+        self.custom_info['cache'][key]['datetime'] = datetime.now()
+
+
+    def get_dataframe_from_cache(self, pair: str, tf: str) -> DataFrame:
+        """
+        Get a dataframe from the cache, if present.
+
+        :param pair: The pair to get the dataframe for
+        :param tf: The timeframe to the dataframe for
+        :return DataFrame: Dataframe for the pair and specified timeframe, or None of not found
+        """
+
+        key = f"{pair}_{tf}"
+        if key in self.custom_info['cache']:
+            return self.custom_info['cache'][key]['df']
+
+        return None
+
+
+    def refresh_data_required(self, old_df: DataFrame, new_df: DataFrame) -> bool:
+        """
+        Determine if the cached dataframe needs to be refreshed (and data needs to be 
+        recalculated). Last candle of both dataframes is compared for this.
+
+        :param old_df: Previous DataFrame
+        :param new_df: Current DataFrame
+        :return bool: True if the last candle doesn't match, otherwise False        
+        """
+
+        refresh = False
+        if old_df is None:
+            refresh = True
+        else:
+            last_old_candle = old_df.iloc[-1].squeeze()
+            last_new_candle = new_df.iloc[-1].squeeze()
+
+            if last_old_candle['date'] != last_new_candle['date']:
+                refresh = True
+
+        return refresh
+
+
+    def cleanup_cache(self):
+        """
+        Cleanup the cache with stored dataframes if the last updated time has passed (with a margin of two minutes).
+        """
+
+        outdatedkeys = []
+
+        currentdatetime = datetime.now()
+        for key in self.custom_info['cache']:
+            minutes = (currentdatetime - self.custom_info['cache'][key]['datetime']).total_seconds() / 60
+            
+            if (minutes - 2) > timeframe_to_minutes(self.custom_info['cache'][key]['tf']):
+                outdatedkeys.append(key)
+
+                self.log(f"Removing cache storage for '{key}' because last update was {minutes} minutes ago")
+
+        for key in outdatedkeys:
+            del self.custom_info['cache'][key]

--- a/base_strategy.py
+++ b/base_strategy.py
@@ -43,7 +43,7 @@ class BaseStrategy(IStrategy):
     # Check the documentation or the Sample strategy to get the latest version.
     INTERFACE_VERSION = 3
 
-    STRATEGY_VERSION_BASE = "1.7.0"
+    STRATEGY_VERSION_BASE = "1.7.1"
 
     # Optimal timeframe for the strategy.
     timeframe = '1h'
@@ -294,7 +294,7 @@ class BaseStrategy(IStrategy):
         # the trade will only be closed when the total amount has been sold
         # TODO: monitor what will happen with partially filled 'sell' orders
         if order.ft_order_side == trade.exit_side and not trade.is_open:
-            custompairkey = self.get_custom_pairkey(trade)
+            custompairkey = self.get_custom_pairkey(trade.pair, trade.trade_direction)
             del self.custom_info[custompairkey]
 
             self.log(f"Removed custom data storage for '{custompairkey}'")
@@ -376,15 +376,16 @@ class BaseStrategy(IStrategy):
             self.log(f"Created custom data storage for pair {pair_key}.")
 
 
-    def get_custom_pairkey(self, trade: 'Trade') -> str:
+    def get_custom_pairkey(self, pair: str, side: str) -> str:
         """
         Get the custom pairkey used for runtime storage of trade data
 
-        :param trade: Trade object to fetch the pairkey for
+        :param pair: Trading pair
+        :param side: Direction of the trade (long/short)
         :return str: The composed pairkey
         """
 
-        return f"{trade.pair}_{trade.trade_direction}"
+        return f"{pair}_{side}"
 
 
     def get_round_digits(self, pair: str) -> int:

--- a/dca_strategy.py
+++ b/dca_strategy.py
@@ -262,6 +262,8 @@ class DCAStrategy(BaseStrategy):
         min_entry_cost = pairdata['limits']['cost']['min']
 
         bo_so_factor = self.get_boso_factor()
+        # TODO: calculate so_amount based on bo price reduced by the percentages the first SO will be bought on. This is 
+        # actually lower than the bo price, and must be kept into account (price limit could be on the verge)
         so_amount = amount * bo_so_factor
         so_cost = (amount * rate) * bo_so_factor
 
@@ -423,7 +425,7 @@ class DCAStrategy(BaseStrategy):
                         f"threshold {(next_safety_order_percentage - tso_start_percentage):.4f}%; reset trailing.",
                         notify=self.notify_trailing_reset
                     )
-
+                # Else case: trailing did not start and we don't need to do anything
                 return None
 
             # Increase trailing when profit has increased (in a negative way)
@@ -449,6 +451,7 @@ class DCAStrategy(BaseStrategy):
                     "DEBUG"
                 )
                 return None
+            # Else case: trailing passed the threshold and additional order can be placed
 
         # Oke, time to add a Safety Order!
         # Calculate order(s) to be filled. Can be more than one order when there's been a huge drop

--- a/dca_strategy.py
+++ b/dca_strategy.py
@@ -12,6 +12,7 @@ from typing import Optional
 # --------------------------------
 # Add your lib to import here
 from freqtrade.constants import Config
+from freqtrade.exchange.exchange_utils_timeframe import timeframe_to_minutes
 from freqtrade.persistence import Order, Trade
 
 from .base_strategy import BaseStrategy
@@ -37,7 +38,7 @@ class DCAStrategy(BaseStrategy):
     # Check the documentation or the Sample strategy to get the latest version.
     INTERFACE_VERSION = 3
 
-    STRATEGY_VERSION_DCA = "1.7.0"
+    STRATEGY_VERSION_DCA = "1.7.1"
 
     # Max number of safety orders (-1 means disabled)
     max_entry_position_adjustment = -1
@@ -205,7 +206,7 @@ class DCAStrategy(BaseStrategy):
         # Create custom data required for DCA
         opentrades = Trade.get_trades_proxy(is_open=True)
         for opentrade in opentrades:
-            custompairkey = self.get_custom_pairkey(opentrade)
+            custompairkey = self.get_custom_pairkey(opentrade.pair, opentrade.trade_direction)
             self.initialize_custom_data(custompairkey)
 
 
@@ -256,26 +257,32 @@ class DCAStrategy(BaseStrategy):
                 return False
 
         # Check min stake amount required for the exchange, and keeping the bo:so into account
+        # Fetch market data uncluding trading limits
         pairdata = self.dp.market(pair)
 
         min_entry_amount = pairdata['limits']['amount']['min']
         min_entry_cost = pairdata['limits']['cost']['min']
 
+        # Get our BO:SO factor
         bo_so_factor = self.get_boso_factor()
-        # TODO: calculate so_amount based on bo price reduced by the percentages the first SO will be bought on. This is 
-        # actually lower than the bo price, and must be kept into account (price limit could be on the verge)
-        so_amount = amount * bo_so_factor
+
+        # Get percentage of first SO
+        _, configpairkey = self.get_pairkeys(pair, side)
+        so_deviation = self.safety_order_configuration[configpairkey]["price_deviation"]
+
+        # Calculate how much will be bought for the first SO
         so_cost = (amount * rate) * bo_so_factor
+        so_amount = so_cost / (rate * (1.0 - (so_deviation / 100.0)))
 
         if so_amount < min_entry_amount or so_cost < min_entry_cost:
             self.log(
-                f"{pair}: trading limit for a SO cannot be statisfied based on {self.trade_bo_so_ratio} ratio. "
+                f"{pair}: trading limit for first SO (on -{so_deviation:.2f}%) cannot be statisfied based on {self.trade_bo_so_ratio} ratio. "
                 f"Safety Order amount {so_amount} (based on BO amount {amount}) is lower than {min_entry_amount} and/or "
                 f"cost {so_cost} is lower than {min_entry_cost}. "
                 f"Not starting this trade.",
                 "WARNING"
             )
-            self.lock_pair(pair, until=current_time + timedelta(minutes=1), reason="Min order limits could not be statisfied")
+            self.lock_pair(pair, until=current_time + timedelta(minutes=timeframe_to_minutes(self.timeframe)), reason="Min order limits could not be statisfied")
             return False
 
         self.initialize_custom_data(pairkey)
@@ -297,7 +304,7 @@ class DCAStrategy(BaseStrategy):
         super().order_filled(pair, trade, order, current_time)
 
         if order.ft_order_side == trade.entry_side:
-            custompairkey = self.get_custom_pairkey(trade)
+            custompairkey = self.get_custom_pairkey(trade.pair, trade.trade_direction)
             openorders = len(self.custom_info[custompairkey]["open_safety_orders"])
             if openorders > 0:
                 # Check if the first order from the list has been bought. Remove the bought order and check if there are other
@@ -373,7 +380,7 @@ class DCAStrategy(BaseStrategy):
             return None
 
         # Create pairkey, or use 'default' 
-        custompairkey, configpairkey = self.get_pairkeys(trade)
+        custompairkey, configpairkey = self.get_pairkeys(trade.pair, trade.trade_direction)
 
         # Return when all Safety Orders are executed
         count_of_entries = trade.nr_of_successful_entries
@@ -701,15 +708,16 @@ class DCAStrategy(BaseStrategy):
         self.custom_info[custom_pair_key]["open_safety_orders"] = list() # List of open Safety Orders to buy
 
 
-    def get_pairkeys(self, trade: 'Trade') -> tuple[str, str]:
+    def get_pairkeys(self, pair: str, side: str) -> tuple[str, str]:
         """
         Get the custom pairkey used for runtime storage of trade data.
 
-        :param trade: Trade object of the trade for which the pairkeys should be fetched
+        :param pair: Trading pair
+        :param side: Direction of the trade (long/short)
         :return tuple[str, str]: key for custom data storage, and key for configuration data
         """
 
-        custompairkey = super().get_custom_pairkey(trade)
+        custompairkey = super().get_custom_pairkey(pair, side)
         configpairkey = custompairkey
         if not configpairkey in self.safety_order_configuration:
             configpairkey = "default"


### PR DESCRIPTION
Improved trading limit calculation by using the first SO instead of the BO value. Add mechanism to cache dataframes to avoid recalculation of the indicators (especially helpful with more indicators). CPU vs RAM optimalization. 